### PR TITLE
Simplify cursor return paths

### DIFF
--- a/lib/models/cursor.js
+++ b/lib/models/cursor.js
@@ -22,20 +22,17 @@ Cursor.prototype._handleRequest = function(base, result) {
   if (result.code == HttpResult.OK) {
     var json = JSON.parse(result.body);
     var payload = json[base._segmentKey];
-    
+
+    payload.forEach(function(item) {
+      base.emit('data', base._obj.fromJSON(item));
+    });
+
     if (json.next_page) {
-      payload.forEach(function(item) {
-        base.emit('data', base._obj.fromJSON(item));
-      });
       base._loadFromServer(base, json.next_page.next_query)
-      return {};
     } else {
-      payload.forEach(function(item) {
-        base.emit('data', base._obj.fromJSON(item));
-      });
       base.emit('end');
-      return {};
     }
+    return {};
   } else {
     var err = new Error(result.body);
     err.code = result.code;


### PR DESCRIPTION
Small cleanup I noticed while reading through the cursor code.
