### PR TITLE
Always emit errors inside the cursor [#82907216]

### DIFF
--- a/lib/models/cursor.js
+++ b/lib/models/cursor.js
@@ -6,8 +6,12 @@ var EventEmitter = require('events').EventEmitter;
 
 util.inherits(Cursor, EventEmitter);
 
-var _handleError = function(err, obj) {
-  if (err) throw err;
+var _handleError = function(base) {
+  return function(err, obj) {
+    if (err) {
+      base.emit('error', err);
+    }
+  }
 }
 
 function Cursor(obj, session, route, query, headers, segmentKey) {
@@ -19,7 +23,8 @@ function Cursor(obj, session, route, query, headers, segmentKey) {
   this._segmentKey = segmentKey || "data";
 }
 
-Cursor.prototype._handleRequest = function(base, result) {
+Cursor.prototype._handleRequest = function(result) {
+  var base = this;
   if (result.code == HttpResult.OK) {
     var json = JSON.parse(result.body);
     var payload = json[base._segmentKey];
@@ -29,7 +34,7 @@ Cursor.prototype._handleRequest = function(base, result) {
     });
 
     if (json.next_page) {
-      base._loadFromServer(base, json.next_page.next_query)
+      base._loadFromServer(json.next_page.next_query);
     } else {
       base.emit('end');
     }
@@ -41,21 +46,17 @@ Cursor.prototype._handleRequest = function(base, result) {
   }
 }
 
-Cursor.prototype._loadFromServer = function(base, body) {
+Cursor.prototype._loadFromServer = function(body) {
+  var base = this;
   var payload = JSON.stringify(body) || JSON.stringify(base._query)
-  base._session.get(base._route, payload, base._headers, _handleError, function(result) {
-    base._handleRequest(base, result)
+  base._session.get(base._route, payload, base._headers, _handleError(base), function(result) {
+    base._handleRequest(result)
     return {}
   });
 }
 
 Cursor.prototype.run = function() {
-  var base = this;
-  try {
-    base._loadFromServer(base)
-  } catch (e) {
-    base.emit('error', e);
-  }
+  this._loadFromServer();
 }
 
 Cursor.prototype.toArray = function(callback) {

--- a/test/test_client.js
+++ b/test/test_client.js
@@ -4,6 +4,7 @@ var assert = require("assert");
 var tempoiq = require("../lib/tempoiq");
 
 var StubbedSession = require("../lib/session/stubbed_session");
+var LiveSession = require("../lib/session/live_session");
 
 // Tag test devices with a unique-ish attribute and key prefix so they're 
 // unlikely to conflict with existing devices in the backend
@@ -100,6 +101,22 @@ describe("Client", function() {
       assert.equal("secret", client.secret);
       assert.equal("host", client.host);
       assert.equal(80, client.port);
+    });
+
+    it("invokes callbacks even in the face of connection issues", function() {
+      var opts = {
+        port: 23432,
+        secure: false
+      };
+      if (!process.env.INTEGRATION) {
+        opts.session = new StubbedSession();
+      }
+
+      var client = tempoiq.Client("key", "secret", "not-found-hostname", opts);
+
+      client.listDevices({devices: "all"}, function(err, devices) {
+        if (!err) throw new Error("Should have received an error");
+      });
     });
   })
 


### PR DESCRIPTION
Because IO is executed asynchronously, our `try catch` block was never wrapping exceptions and converting them to `emit` calls. Now we explicitly will bubble up exceptions through `emit` via the `_handleError` call.
