### PR TITLE
Parameterize http(s) agent

### DIFF
--- a/lib/session/live_session.js
+++ b/lib/session/live_session.js
@@ -14,11 +14,11 @@ function LiveSession(key, secret, host, port, opts) {
   this.port = port;
   this.opts = opts;
   this.connection = opts.secure ? https : http;
-  this.maxconnections = opts.maxconnections ? opts.maxconnections : 10;
-  this.connection.globalAgent.maxSockets = this.maxconnections;
+  this.agent = opts.agent === undefined ? this.connection.globalAgent : opts.agent
+
   this.defaultHeaders = {
     'Accept-Encoding': 'gzip',
-    'User-Agent': 'tempoiq-nodejs/'.concat(lib_version),
+    'User-Agent': 'tempoiq-nodejs/'.concat(lib_version)
   };
 }
 
@@ -55,7 +55,8 @@ LiveSession.prototype._execute =  function(verb, route, body, headers, callback,
     path: route,
     method: verb,
     auth: this.key+':'+this.secret,
-    headers: headersToSend
+    headers: headersToSend,
+    agent: this.agent
   };
 
   var req = this.connection.request(options, function(response) {

--- a/lib/tempoiq.js
+++ b/lib/tempoiq.js
@@ -71,11 +71,12 @@ TempoIQ.Client = function(key, secret, host, opts) {
     // TempoIQ backend port
     base.port = opts.port == undefined ? _defaultOptions.port : opts.port;
 
-    // Whether to use SSL or not. Defauls to true.
+    // Whether to use SSL or not. Defaults to true.
     base.secure = opts.secure == undefined ? _defaultOptions.secure : opts.secure;
+    opts.secure = base.secure;      // Make sure secure param is passed down to session
 
     // Makes backend calls, defaults to LiveSession.
-    base._session = opts.session == undefined ? new LiveSession(key, secret, host, base.port, {secure: base.secure}) : opts.session;
+    base._session = opts.session == undefined ? new LiveSession(key, secret, host, base.port, opts) : opts.session;
   };
 
   base._mediaTypes = function(types) {


### PR DESCRIPTION
-Allow users to pass in their own agents to replace the default globalAgent. 
-Remove the maxSockets configuration, since it wasn't actually exposed in the Client constructor, and it can now be accomplished by passing in an agent.