### PR TITLE
Handle empty bodies for older server versions

### DIFF
--- a/lib/tempoiq.js
+++ b/lib/tempoiq.js
@@ -226,10 +226,11 @@ TempoIQ.Client = function(key, secret, host, opts) {
   // @param {function(err, multiStatus)} callback Returns a WriteStatus with the results of the write
   base.writeBulk = function(write, callback) {
     base._session.post("/v2/write", JSON.stringify(write), {}, callback, function(result) {
+      var body = result.body || "{}";
       if (result.code == HttpResult.OK) {
-        return { error: null, payload: new WriteStatus(JSON.parse(result.body)) };
+        return { error: null, payload: new WriteStatus(JSON.parse(body)) };
       } else if (result.code == HttpResult.MULTI) {
-        return { error: null, payload: new WriteStatus(JSON.parse(result.body)) };
+        return { error: null, payload: new WriteStatus(JSON.parse(body)) };
       }
     });
   };


### PR DESCRIPTION
Don't bomb out when encountering an empty response body on writes, as we return in older Tapp versions.

This PR makes the callback's result to be {"status":{}} for successful responses. Previous client versions would have a null result, so this is a behavior change. However I'm OK with it considering it's a code path which will go away once all backends are upgraded.